### PR TITLE
Add cleanup function to avoid memory leak

### DIFF
--- a/src/provider/ContextProvider.js
+++ b/src/provider/ContextProvider.js
@@ -18,6 +18,7 @@ const ContextProvider = ({ children }) => {
   }
 
   const [store, updateStore] = useState(initialStoreState)
+  let isRemoved = false
 
   useEffect(() => {
     const initializeCheckout = async () => {
@@ -44,7 +45,7 @@ const ContextProvider = ({ children }) => {
         try {
           const checkout = await fetchCheckout(existingCheckoutID)
           // Make sure this cart hasn’t already been purchased.
-          if (!checkout.completedAt) {
+          if (!isRemoved && !checkout.completedAt) {
             setCheckoutInState(checkout)
             return
           }
@@ -54,11 +55,15 @@ const ContextProvider = ({ children }) => {
       }
 
       const newCheckout = await createNewCheckout()
-      setCheckoutInState(newCheckout)
+      if (!isRemoved) {
+        setCheckoutInState(newCheckout)
+      }
     }
 
     initializeCheckout()
   }, [store.client.checkout])
+  
+  useEffect(() => () => { isRemoved = true; }, [])
 
   return (
     <Context.Provider


### PR DESCRIPTION
A clean up function is necessary using a second useEffect function to avoid a situation where the async functions finish after the component did unmount.