### PR TITLE
IE11 Fix

### DIFF
--- a/src/provider/ContextProvider.js
+++ b/src/provider/ContextProvider.js
@@ -1,12 +1,16 @@
+import fetch from 'isomorphic-fetch'
 import React, { useState, useEffect } from 'react'
 import Client from 'shopify-buy'
 
 import Context from '~/context/StoreContext'
 
-const client = Client.buildClient({
-  storefrontAccessToken: process.env.SHOPIFY_ACCESS_TOKEN,
-  domain: `${process.env.SHOP_NAME}.myshopify.com`,
-})
+const client = Client.buildClient(
+  {
+    storefrontAccessToken: process.env.SHOPIFY_ACCESS_TOKEN,
+    domain: `${process.env.SHOP_NAME}.myshopify.com`,
+  },
+  fetch
+)
 
 const ContextProvider = ({ children }) => {
   let initialStoreState = {
@@ -28,18 +32,18 @@ const ContextProvider = ({ children }) => {
         ? localStorage.getItem('shopify_checkout_id')
         : null
 
-      const setCheckoutInState = checkout => {
+      const setCheckoutInState = (checkout) => {
         if (isBrowser) {
           localStorage.setItem('shopify_checkout_id', checkout.id)
         }
 
-        updateStore(prevState => {
+        updateStore((prevState) => {
           return { ...prevState, checkout }
         })
       }
 
       const createNewCheckout = () => store.client.checkout.create()
-      const fetchCheckout = id => store.client.checkout.fetch(id)
+      const fetchCheckout = (id) => store.client.checkout.fetch(id)
 
       if (existingCheckoutID) {
         try {
@@ -62,8 +66,13 @@ const ContextProvider = ({ children }) => {
 
     initializeCheckout()
   }, [store.client.checkout])
-  
-  useEffect(() => () => { isRemoved = true; }, [])
+
+  useEffect(
+    () => () => {
+      isRemoved = true
+    },
+    []
+  )
 
   return (
     <Context.Provider
@@ -75,7 +84,7 @@ const ContextProvider = ({ children }) => {
             return
           }
 
-          updateStore(prevState => {
+          updateStore((prevState) => {
             return { ...prevState, adding: true }
           })
 
@@ -88,8 +97,8 @@ const ContextProvider = ({ children }) => {
 
           return client.checkout
             .addLineItems(checkoutId, lineItemsToUpdate)
-            .then(checkout => {
-              updateStore(prevState => {
+            .then((checkout) => {
+              updateStore((prevState) => {
                 return { ...prevState, checkout, adding: false }
               })
             })
@@ -97,8 +106,8 @@ const ContextProvider = ({ children }) => {
         removeLineItem: (client, checkoutID, lineItemID) => {
           return client.checkout
             .removeLineItems(checkoutID, [lineItemID])
-            .then(res => {
-              updateStore(prevState => {
+            .then((res) => {
+              updateStore((prevState) => {
                 return { ...prevState, checkout: res }
               })
             })
@@ -110,8 +119,8 @@ const ContextProvider = ({ children }) => {
 
           return client.checkout
             .updateLineItems(checkoutID, lineItemsToUpdate)
-            .then(res => {
-              updateStore(prevState => {
+            .then((res) => {
+              updateStore((prevState) => {
                 return { ...prevState, checkout: res }
               })
             })


### PR DESCRIPTION
This passes the imported polyfill from 'isomorphic-fetch' to Client.buildClient. Without this, there is an error on IE11 about fetch.

On newer versions of gatsby, shopify plugin is not working with IE11 and I have opened an issue since:
https://github.com/gatsbyjs/gatsby/issues/26734

Good job on making the shopify-starter. It helped me a lot!